### PR TITLE
Link to Instagram instead of rush form

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -25,7 +25,7 @@ const links = [
   },
   {
     title: 'Rush Form',
-    href: 'http://bit.ly/rushutdfiji',
+    href: 'https://www.instagram.com/utdfiji/',
   },
   {
     title: 'Email',

--- a/src/app/recruitment/page.tsx
+++ b/src/app/recruitment/page.tsx
@@ -50,7 +50,11 @@ export default function Recruitment() {
       <Section className="flex flex-col gap-4 items-center">
         <h3 className="text-xl">
           Our{' '}
-          <Link href="http://bit.ly/rushutdfiji" target="_blank" className="font-bold underline">
+          <Link
+            href="https://www.instagram.com/utdfiji/"
+            target="_blank"
+            className="font-bold underline"
+          >
             Rush Form
           </Link>{' '}
           is the best way for us to stay in contact with you at the starts of semesters.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -41,7 +41,7 @@ const groups = [
       },
       {
         title: 'Rush Form',
-        href: 'http://bit.ly/rushutdfiji',
+        href: 'https://www.instagram.com/utdfiji/',
       },
       {
         title: 'Purchase',


### PR DESCRIPTION
The rush form doesn't have a consistent link so I set the links to just go to Instagram, which will be up to date.