### PR TITLE
Replace ticket links with Zeffy modals and NFCDA Dinner

### DIFF
--- a/src/app/tickets/page.tsx
+++ b/src/app/tickets/page.tsx
@@ -1,6 +1,7 @@
 import BrothersDinner from '@/../public/headers/brothers-dinners.jpg';
 import Page from '@/components/Page';
 import Section from '@/components/Section';
+import ZeffyModalCard from '@/components/ZeffyModalCard';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import React from 'react';
@@ -25,17 +26,19 @@ const offerings = [
     price: 'Starting at $5/month',
     description:
       'Become a steward of the Tau Delta legacy. Choose a subscription tier that works for you and help ensure the Royal Purple remains a standard of excellence, providing the financial backbone for undergraduate brothers to lead, learn, and grow.',
-    href: 'https://www.zeffy.com/en-US/ticketing/tau-delta-fiji-monthly-donation-subscription-1848-club',
+    formLink:
+      'https://www.zeffy.com/embed/ticketing/tau-delta-fiji-monthly-donation-subscription-1848-club?modal=true',
     featured: true,
     buttonText: 'Join Now',
   },
   {
-    title: '14th Annual Frank Norris Pig Dinner',
+    title: 'NFCDA Dinner',
     subtitle: 'Event Tickets',
     price: 'Purchase Tickets',
     description:
-      'Join us for the 14th Annual Frank Norris Pig Dinner, hosted by the Tau Delta Chapter of FIJI. Click here to purchase your tickets for this special event.',
-    href: 'https://www.zeffy.com/en-US/ticketing/14th-annual-frank-norris-pig-dinner',
+      'Join us for the NFCDA Dinner, hosted by the Tau Delta Chapter of FIJI. Purchase your tickets without leaving this page.',
+    formLink:
+      'https://www.zeffy.com/embed/ticketing/nfcda-not-for-college-days-alone-dinner?modal=true',
     featured: true,
     buttonText: 'Purchase Tickets',
   },
@@ -58,65 +61,16 @@ export default function Tickets() {
 
         <div className="grid gap-6 w-full max-w-3xl">
           {offerings.map((offering) => (
-            <Link
+            <ZeffyModalCard
               key={offering.title}
-              href={offering.href}
-              target="_blank"
-              className={`group relative overflow-hidden rounded-2xl p-8 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl ${
-                offering.featured
-                  ? 'bg-gradient-to-br from-purple to-purple/80 text-white shadow-xl'
-                  : 'bg-white text-dark-grey shadow-lg border border-gray-200'
-              }`}
-            >
-              {offering.featured && (
-                <div className="absolute top-4 right-4 bg-yellow text-purple text-xs font-bold px-3 py-1 rounded-full">
-                  RECOMMENDED
-                </div>
-              )}
-
-              <div className="flex flex-col gap-4">
-                <div>
-                  <p
-                    className={`text-sm font-medium ${offering.featured ? 'text-yellow' : 'text-purple'}`}
-                  >
-                    {offering.subtitle}
-                  </p>
-                  <h3 className="text-3xl font-bold font-display">{offering.title}</h3>
-                </div>
-
-                <p
-                  className={`text-4xl font-bold ${offering.featured ? 'text-white' : 'text-purple'}`}
-                >
-                  {offering.price}
-                </p>
-
-                <p className={`${offering.featured ? 'text-white/90' : 'text-medium-grey'}`}>
-                  {offering.description}
-                </p>
-
-                <div
-                  className={`mt-4 inline-flex items-center gap-2 font-bold transition-all group-hover:gap-4 ${
-                    offering.featured ? 'text-yellow' : 'text-purple'
-                  }`}
-                >
-                  {offering.buttonText || 'Learn More'}
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M5 12h14" />
-                    <path d="m12 5 7 7-7 7" />
-                  </svg>
-                </div>
-              </div>
-            </Link>
+              title={offering.title}
+              subtitle={offering.subtitle}
+              price={offering.price}
+              description={offering.description}
+              buttonText={offering.buttonText}
+              formLink={offering.formLink}
+              featured={offering.featured}
+            />
           ))}
         </div>
 

--- a/src/components/ZeffyModalCard.tsx
+++ b/src/components/ZeffyModalCard.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useEffect, useId, useState } from 'react';
+
+type ZeffyModalCardProps = {
+  title: string;
+  subtitle: string;
+  price: string;
+  description: string;
+  buttonText?: string;
+  formLink: string;
+  featured?: boolean;
+};
+
+export default function ZeffyModalCard({
+  title,
+  subtitle,
+  price,
+  description,
+  buttonText = 'Purchase Tickets',
+  formLink,
+  featured = false,
+}: ZeffyModalCardProps) {
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`group relative overflow-hidden rounded-2xl p-8 text-left transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl w-full cursor-pointer ${
+          featured
+            ? 'bg-gradient-to-br from-purple to-purple/80 text-white shadow-xl'
+            : 'bg-white text-dark-grey shadow-lg border border-gray-200'
+        }`}
+      >
+        {featured && (
+          <div className="absolute top-4 right-4 bg-yellow text-purple text-xs font-bold px-3 py-1 rounded-full">
+            RECOMMENDED
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className={`text-sm font-medium ${featured ? 'text-yellow' : 'text-purple'}`}>
+              {subtitle}
+            </p>
+            <h3 className="text-3xl font-bold font-display">{title}</h3>
+          </div>
+
+          <p className={`text-4xl font-bold ${featured ? 'text-white' : 'text-purple'}`}>{price}</p>
+
+          <p className={`${featured ? 'text-white/90' : 'text-medium-grey'}`}>{description}</p>
+
+          <div
+            className={`mt-4 inline-flex items-center gap-2 font-bold transition-all group-hover:gap-4 ${
+              featured ? 'text-yellow' : 'text-purple'
+            }`}
+          >
+            {buttonText}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </div>
+        </div>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[10000] flex items-center justify-center p-0 md:p-8"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+        >
+          <button
+            type="button"
+            aria-label="Close ticket form"
+            className="absolute inset-0 bg-purple/70 backdrop-blur-sm"
+            onClick={() => setOpen(false)}
+          />
+
+          <div className="relative z-10 flex h-full w-full flex-col overflow-hidden bg-white shadow-2xl md:h-[90vh] md:max-w-5xl md:rounded-2xl">
+            <div className="flex items-center justify-between gap-4 bg-purple px-4 py-3 text-white md:px-6">
+              <h2 id={titleId} className="font-display text-lg font-bold md:text-xl truncate">
+                {title}
+              </h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-full bg-yellow px-3 py-1 text-sm font-bold text-purple transition hover:brightness-110"
+              >
+                Close
+              </button>
+            </div>
+
+            <iframe
+              title="Form powered and secured by Zeffy"
+              src={`${formLink}${formLink.includes('?') ? '&' : '?'}cachebust=${Date.now()}`}
+              className="h-full w-full flex-1 border-0 bg-white"
+              allow="payment"
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ZeffyModalCard.tsx
+++ b/src/components/ZeffyModalCard.tsx
@@ -22,7 +22,14 @@ export default function ZeffyModalCard({
   featured = false,
 }: ZeffyModalCardProps) {
   const [open, setOpen] = useState(false);
+  const [iframeSrc, setIframeSrc] = useState<string | null>(null);
   const titleId = useId();
+
+  const openModal = () => {
+    const separator = formLink.includes('?') ? '&' : '?';
+    setIframeSrc(`${formLink}${separator}cachebust=${Date.now()}`);
+    setOpen(true);
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -45,7 +52,7 @@ export default function ZeffyModalCard({
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={openModal}
         className={`group relative overflow-hidden rounded-2xl p-8 text-left transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl w-full cursor-pointer ${
           featured
             ? 'bg-gradient-to-br from-purple to-purple/80 text-white shadow-xl'
@@ -123,12 +130,14 @@ export default function ZeffyModalCard({
               </button>
             </div>
 
-            <iframe
-              title="Form powered and secured by Zeffy"
-              src={`${formLink}${formLink.includes('?') ? '&' : '?'}cachebust=${Date.now()}`}
-              className="h-full w-full flex-1 border-0 bg-white"
-              allow="payment"
-            />
+            {iframeSrc && (
+              <iframe
+                title="Form powered and secured by Zeffy"
+                src={iframeSrc}
+                className="h-full w-full flex-1 border-0 bg-white"
+                allow="payment"
+              />
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replace external Zeffy ticket links with branded in-page modals for Monthly Subscription and NFCDA Dinner
- Remove the Frank Norris Pig Dinner card and add NFCDA Dinner using the Zeffy embed
- Keep purchase cards visually consistent with existing featured styling

## Test plan
- [ ] Open `/tickets` and confirm Pig Dinner card is gone
- [ ] Confirm subscription card opens the Zeffy modal (not a new tab)
- [ ] Confirm NFCDA Dinner card opens its Zeffy modal
- [ ] Verify modal styling matches site (purple header, yellow close, rounded frame)
- [ ] Close via backdrop, Close button, and Escape

Made with [Cursor](https://cursor.com)